### PR TITLE
Enforce maximum username length on server side

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,10 @@ console.log("A new user has joined Whittr!")
       return callback('Name and room name are required.');
     }
 
+    if (params.name.length > 16) {
+      return callback('Name cannot be more than 16 characters.');
+    }
+
     socket.join(params.room);
     users.removeUser(socket.id);
     users.addUser(socket.id, params.name, params.room);


### PR DESCRIPTION
Currently, the limit of max 16 characters is only enforced by the HTML `maxlength` attribute. This means that by editing the URI in the browser bar, users can have longer names. Long names overflow the sidebar.

# Unicode considerations

Both the HTML `maxlength` attribute and JavaScript's `.length` are in UTF-16 units, so this is consistent.